### PR TITLE
Update Amazon.js

### DIFF
--- a/lib/Amazon.js
+++ b/lib/Amazon.js
@@ -105,6 +105,7 @@ class AmazonScraper {
                     'accept-encoding': 'gzip, deflate, br',
                     te: 'trailers',
                 },
+                strictSSL: false,
                 ...(json ? { json: true } : {}),
                 gzip: true,
                 resolveWithFullResponse: true,


### PR DESCRIPTION
Action: Fetch data with proxy https://www.scraperapi.com/ 
Expected Outcome: Get the data
Actual Outcome: Error: unable to verify the first certificate

Solution add strictSSL: false in the request options.