### PR TITLE
Update Amazon.js - Fixing verified purchase check & parsing total number of reviews

### DIFF
--- a/lib/Amazon.js
+++ b/lib/Amazon.js
@@ -423,7 +423,7 @@ class AmazonScraper {
         /**
          * Get total number of reviews
          */
-        this.reviewMetadata.total_reviews = parseInt($('.averageStarRatingNumerical').text(), 10);
+        this.reviewMetadata.total_reviews = parseInt($('.averageStarRatingNumerical').text().replace(/,/ig, ''), 10);
 
         const reviewsList = $('#cm_cr-review_list')[0].children;
         let scrapingResult = {};
@@ -533,7 +533,7 @@ class AmazonScraper {
          * If purchase is verified
          */
         for (let key in scrapingResult) {
-            const search = $(`#${key} [data-reftag="cm_cr_arp_d_rvw_rvwer"]`);
+            const search = $(`#${key} [data-hook="avp-badge"]`);
             scrapingResult[key].verified_purchase = false;
 
             try {


### PR DESCRIPTION
1. Selector of verified purchase badge is different on amazon than what is used in this package. So, I Updated Selector where it checks if purchase is verified while scraping reviews and now it gets it correctly.
2. "Get total number of reviews" didn't get the number correctly if there is a comma in number like 1,345. If comma exists, it only returns the number present before comma (1 in case of 1,345). I added replace function there to get rid of commas before parseInt uses it. So, After I Updated this code now it gets total number of reviews correctly.