### PR TITLE
Fix missing current_price in products data

### DIFF
--- a/lib/Amazon.js
+++ b/lib/Amazon.js
@@ -1242,7 +1242,7 @@ class AmazonScraper {
 
         for (let key in scrapingResult) {
             try {
-                const priceSearch = $(`div[data-asin=${key}] span[data-a-size="l"]`)[0] || $(`div[data-asin=${key}] span[data-a-size="m"]`)[0];
+                const priceSearch = $(`div[data-asin=${key}] span[data-a-size="xl"]`)[0] ||  $(`div[data-asin=${key}] span[data-a-size="l"]`)[0] || $(`div[data-asin=${key}] span[data-a-size="m"]`)[0];
                 const discountSearch = $(`div[data-asin=${key}] span[data-a-strike="true"]`)[0];
                 const ratingSearch = $(`div[data-asin=${key}] .a-icon-star-small`)[0];
                 const titleThumbnailSearch = $(`div[data-asin=${key}] [data-image-source-density="1"]`)[0];


### PR DESCRIPTION
Currently, the `current_price` field is no longer being retrieved correctly by the scraper due to the changed html. 
I fixed it by adding a condition to the current price selector.